### PR TITLE
Added useNativeDriver flag to Animated.timing

### DIFF
--- a/src/EllipsisLoading.js
+++ b/src/EllipsisLoading.js
@@ -62,6 +62,7 @@ const animateDots = (whichDot, animateDotsParam, animationState, props) => {
 
   Animated.timing(animationState.dotOpacities[whicDotTmp], {
     toValue: animationState.targetOpacity,
+    useNativeDriver : true,
     duration: animationDelay,
   }).start(() =>
     animateDotsParam(nextDot, animateDotsParam, animationState, props),


### PR DESCRIPTION
Added useNativeDriver flag to Animated.timing, as required to the last ReactNative version


I was running in iPhone, and face up this warning